### PR TITLE
[Feature]: [BE] 모임-회원 간 연결 테이블 설정 등

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/group/dto/request/GroupRequest.java
+++ b/backend/src/main/java/com/app/backend/domain/group/dto/request/GroupRequest.java
@@ -18,6 +18,7 @@ public class GroupRequest {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Create {
+        private Long    memberId;
         @NotNull
         @NotBlank
         private String  name;
@@ -45,6 +46,7 @@ public class GroupRequest {
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Update {
         private Long    groupId;
+        private Long    memberId;
         @NotNull
         @NotBlank
         private String  name;

--- a/backend/src/main/java/com/app/backend/domain/group/entity/Group.java
+++ b/backend/src/main/java/com/app/backend/domain/group/entity/Group.java
@@ -2,7 +2,6 @@ package com.app.backend.domain.group.entity;
 
 import com.app.backend.domain.chat.room.entity.ChatRoom;
 import com.app.backend.global.entity.BaseEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,16 +11,20 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Table(name = "tbl_groups")
@@ -59,8 +62,13 @@ public class Group extends BaseEntity {
     @Min(1)
     private Integer maxRecruitCount;    //모임 최대 인원
 
+    @OneToMany(mappedBy = "group")
+    @Builder.Default
+    private List<GroupMembership> members = new ArrayList<>();  //모임 내 회원(다대다 연관관계 중간 테이블)
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_room_id")
+    @Setter(AccessLevel.PUBLIC)
     private ChatRoom chatRoom;      // 채팅방
 
     //============================== 모임(Group) 수정 메서드 ==============================//

--- a/backend/src/main/java/com/app/backend/domain/group/entity/GroupMembership.java
+++ b/backend/src/main/java/com/app/backend/domain/group/entity/GroupMembership.java
@@ -1,0 +1,76 @@
+package com.app.backend.domain.group.entity;
+
+import com.app.backend.domain.member.entity.Member;
+import com.app.backend.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "tbl_group_memberships")
+@IdClass(GroupMembershipId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GroupMembership extends BaseEntity {
+
+    @Id
+    @Column(name = "member_id", insertable = false, updatable = false)
+    private Long memberId;  //회원 ID
+
+    @Id
+    @Column(name = "group_id", insertable = false, updatable = false)
+    private Long groupId;   //모임 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", insertable = false, updatable = false)
+    private Member member;  //회원
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", insertable = false, updatable = false)
+    private Group group;    //모임
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private GroupRole groupRole;    //모임 내 회원의 권한: LEADER, PARTICIPANT
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MembershipStatus status;    //모임 내 회원의 상태: PENDING, APPROVED, REJECTED
+
+    @Builder
+    public GroupMembership(@NotNull final Member member,
+                           @NotNull final Group group,
+                           @NotNull final GroupRole groupRole) {
+        setRelationshipWithMember(member);
+        setRelationshipWithGroup(group);
+        this.groupRole = groupRole;
+        this.status = groupRole == GroupRole.LEADER ? MembershipStatus.APPROVED : MembershipStatus.PENDING;
+    }
+
+    //============================== 연관관계 메서드 ==============================//
+
+    private void setRelationshipWithMember(@NotNull final Member member) {
+        memberId = member.getId();
+        this.member = member;
+        //TODO: 필요 시, 회원(Member)과의 연관관계 설정 추가
+    }
+
+    private void setRelationshipWithGroup(@NotNull final Group group) {
+        groupId = group.getId();
+        this.group = group;
+        group.getMembers().add(this);
+    }
+
+}

--- a/backend/src/main/java/com/app/backend/domain/group/entity/GroupMembershipId.java
+++ b/backend/src/main/java/com/app/backend/domain/group/entity/GroupMembershipId.java
@@ -1,0 +1,19 @@
+package com.app.backend.domain.group.entity;
+
+import java.io.Serializable;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class GroupMembershipId implements Serializable {
+    private Long memberId;
+    private Long groupId;
+}

--- a/backend/src/main/java/com/app/backend/domain/group/entity/GroupRole.java
+++ b/backend/src/main/java/com/app/backend/domain/group/entity/GroupRole.java
@@ -1,0 +1,5 @@
+package com.app.backend.domain.group.entity;
+
+public enum GroupRole {
+    LEADER, PARTICIPANT
+}

--- a/backend/src/main/java/com/app/backend/domain/group/entity/MembershipStatus.java
+++ b/backend/src/main/java/com/app/backend/domain/group/entity/MembershipStatus.java
@@ -1,0 +1,5 @@
+package com.app.backend.domain.group.entity;
+
+public enum MembershipStatus {
+    PENDING, APPROVED, REJECTED
+}

--- a/backend/src/main/java/com/app/backend/domain/group/exception/GroupMembershipErrorCode.java
+++ b/backend/src/main/java/com/app/backend/domain/group/exception/GroupMembershipErrorCode.java
@@ -8,9 +8,10 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum GroupErrorCode implements DomainErrorCode {
+public enum GroupMembershipErrorCode implements DomainErrorCode {
 
-    GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "GR001", "모임을 찾지 못함");
+    GROUP_MEMBERSHIP_NOT_FOUND(HttpStatus.BAD_REQUEST, "GM001", "모임 멤버십을 찾을 수 없음"),
+    GROUP_MEMBERSHIP_NO_PERMISSION(HttpStatus.FORBIDDEN, "GM002", "모임 수정 권한이 없음");
 
     private final HttpStatus status;
     private final String     code;

--- a/backend/src/main/java/com/app/backend/domain/group/exception/GroupMembershipException.java
+++ b/backend/src/main/java/com/app/backend/domain/group/exception/GroupMembershipException.java
@@ -1,0 +1,10 @@
+package com.app.backend.domain.group.exception;
+
+import com.app.backend.global.error.exception.DomainErrorCode;
+import com.app.backend.global.error.exception.DomainException;
+
+public class GroupMembershipException extends DomainException {
+    public GroupMembershipException(final DomainErrorCode domainErrorCode) {
+        super(domainErrorCode);
+    }
+}

--- a/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepository.java
+++ b/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepository.java
@@ -1,0 +1,39 @@
+package com.app.backend.domain.group.repository;
+
+import com.app.backend.domain.group.entity.GroupMembership;
+import com.app.backend.domain.group.entity.GroupMembershipId;
+import com.app.backend.domain.group.entity.GroupRole;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMembershipRepository extends JpaRepository<GroupMembership, GroupMembershipId>,
+                                                   GroupMembershipRepositoryCustom {
+
+    Optional<GroupMembership> findByGroupIdAndMemberId(Long groupId, Long memberId);
+
+    Optional<GroupMembership> findByGroupIdAndMemberIdAndDisabled(Long groupId, Long memberId, Boolean disabled);
+
+    List<GroupMembership> findAllByGroupId(Long groupId);
+
+    List<GroupMembership> findAllByGroupIdAndDisabled(Long groupId, Boolean disabled);
+
+    List<GroupMembership> findAllByMemberId(Long memberId);
+
+    List<GroupMembership> findAllByMemberIdAndDisabled(Long memberId, Boolean disabled);
+
+    List<GroupMembership> findAllByGroupRole(GroupRole groupRole);
+
+    List<GroupMembership> findAllByGroupRoleAndDisabled(GroupRole groupRole, Boolean disabled);
+
+    List<GroupMembership> findAllByGroupIdAndGroupRole(Long groupId, GroupRole groupRole);
+
+    List<GroupMembership> findAllByGroupIdAndGroupRoleAndDisabled(Long groupId, GroupRole groupRole, Boolean disabled);
+
+    List<GroupMembership> findAllByMemberIdAndGroupRole(Long memberId, GroupRole groupRole);
+
+    List<GroupMembership> findAllByMemberIdAndGroupRoleAndDisabled(Long memberId,
+                                                                   GroupRole groupRole,
+                                                                   Boolean disabled);
+
+}

--- a/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryCustom.java
+++ b/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.app.backend.domain.group.repository;
+
+public interface GroupMembershipRepositoryCustom {
+}

--- a/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryImpl.java
+++ b/backend/src/main/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryImpl.java
@@ -1,0 +1,13 @@
+package com.app.backend.domain.group.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GroupMembershipRepositoryImpl implements GroupMembershipRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+}

--- a/backend/src/main/java/com/app/backend/domain/group/service/GroupService.java
+++ b/backend/src/main/java/com/app/backend/domain/group/service/GroupService.java
@@ -1,12 +1,23 @@
 package com.app.backend.domain.group.service;
 
+import com.app.backend.domain.chat.room.entity.ChatRoom;
+import com.app.backend.domain.chat.room.repository.ChatRoomRepository;
 import com.app.backend.domain.group.dto.request.GroupRequest;
 import com.app.backend.domain.group.dto.response.GroupResponse;
 import com.app.backend.domain.group.entity.Group;
+import com.app.backend.domain.group.entity.GroupMembership;
+import com.app.backend.domain.group.entity.GroupRole;
+import com.app.backend.domain.group.entity.MembershipStatus;
 import com.app.backend.domain.group.entity.RecruitStatus;
 import com.app.backend.domain.group.exception.GroupErrorCode;
 import com.app.backend.domain.group.exception.GroupException;
+import com.app.backend.domain.group.exception.GroupMembershipErrorCode;
+import com.app.backend.domain.group.exception.GroupMembershipException;
+import com.app.backend.domain.group.repository.GroupMembershipRepository;
 import com.app.backend.domain.group.repository.GroupRepository;
+import com.app.backend.domain.member.entity.Member;
+import com.app.backend.domain.member.exception.MemberException;
+import com.app.backend.domain.member.repository.MemberRepository;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -21,7 +32,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GroupService {
 
-    private final GroupRepository groupRepository;
+    private final GroupRepository           groupRepository;
+    private final GroupMembershipRepository groupMembershipRepository;
+    private final MemberRepository          memberRepository;
+    private final ChatRoomRepository        chatRoomRepository;
 
     /**
      * 모임(Group) 저장
@@ -31,7 +45,16 @@ public class GroupService {
      */
     @Transactional
     public Long createGroup(@NotNull final GroupRequest.Create dto) {
-        //TODO: 해당 모임을 생성하는 회원 검증 + 모임 생성 완료 후 모임의 관리자 권한 부여
+        //모임을 생성하는 회원 검증
+        //TODO: MemberException 예외 코드, 메시지 추가 필요
+//        Member member = memberRepository.findByIdAndDisabled(dto.getMemberId(), false)
+//                                        .orElseThrow(() -> new MemberException());
+        Member member = memberRepository.findById(dto.getMemberId())
+                                        .orElseThrow(MemberException::new);
+        if (member.isDisabled())
+            throw new MemberException();
+
+        //모임 엔티티 생성
         Group group = Group.builder()
                            .name(dto.getName())
                            .province(dto.getProvince())
@@ -41,7 +64,24 @@ public class GroupService {
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(dto.getMaxRecruitCount())
                            .build();
-        return groupRepository.save(group).getId();
+        groupRepository.save(group);
+
+        //모임 채팅방 엔티티 생성
+        ChatRoom chatRoom = ChatRoom.builder()
+                                    .group(group)
+                                    .build();
+        chatRoomRepository.save(chatRoom);
+        group.setChatRoom(chatRoom);
+
+        //모임 멤버십 엔티티 생성(회원-모임 연결 테이블, 모임 관리자 권한(LEADER) 부여)
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .member(member)
+                                                         .group(group)
+                                                         .groupRole(GroupRole.LEADER)
+                                                         .build();
+        groupMembershipRepository.save(groupMembership);
+
+        return group.getId();
     }
 
     /**
@@ -175,29 +215,63 @@ public class GroupService {
      */
     @Transactional
     public GroupResponse.Detail modifyGroup(@NotNull final GroupRequest.Update dto) {
-        //TODO: 해당 모임을 수정하려는 회원 검증 + 모임의 관리자 권한 보유 유무 확인
+        GroupMembership groupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(dto.getGroupId(),
+                                                                              dto.getMemberId(),
+                                                                              false)
+                                         .orElseThrow(
+                                                 () -> new GroupMembershipException(
+                                                         GroupMembershipErrorCode.GROUP_MEMBERSHIP_NOT_FOUND
+                                                 )
+                                         );
+
+        //회원의 모임 내 권한 확인
+        if (groupMembership.getGroupRole() != GroupRole.LEADER
+            || groupMembership.getStatus() != MembershipStatus.APPROVED)
+            throw new GroupMembershipException(GroupMembershipErrorCode.GROUP_MEMBERSHIP_NO_PERMISSION);
+
         Group group = groupRepository.findByIdAndDisabled(dto.getGroupId(), false)
                                      .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
         group.modifyName(dto.getName())
              .modifyRegion(dto.getProvince(), dto.getCity(), dto.getTown())
              .modifyDescription(dto.getDescription())
              .modifyRecruitStatus(RecruitStatus.valueOf(dto.getRecruitStatus()))
              .modifyMaxRecruitCount(dto.getMaxRecruitCount());
+
         return GroupResponse.toDetail(group);
     }
 
     /**
      * 모임(Group) 삭제(Soft Delete)
      *
-     * @param groupId - 모임 ID
+     * @param groupId  - 모임 ID
+     * @param memberId - 회원 ID
      * @return 모임 비활성화(disabled) 여부
      */
     @Transactional
-    public boolean deleteGroup(@NotNull @Min(1) final Long groupId) {
-        //TODO: 해당 모임을 삭제하려는 회원 검증 + 모임의 관리자 권한 보유 유무 확인
+    public boolean deleteGroup(@NotNull @Min(1) final Long groupId, @NotNull @Min(1) final Long memberId) {
+        GroupMembership groupMembership = groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(groupId,
+                                                                                                        memberId,
+                                                                                                        false)
+                                                                   .orElseThrow(
+                                                                           () -> new GroupMembershipException(
+                                                                                   GroupMembershipErrorCode
+                                                                                           .GROUP_MEMBERSHIP_NOT_FOUND
+                                                                           )
+                                                                   );
+
+        //회원의 모임 내 권한 확인
+        if (groupMembership.getGroupRole() != GroupRole.LEADER
+            || groupMembership.getStatus() != MembershipStatus.APPROVED)
+            throw new GroupMembershipException(GroupMembershipErrorCode.GROUP_MEMBERSHIP_NO_PERMISSION);
+
         Group group = groupRepository.findByIdAndDisabled(groupId, false)
                                      .orElseThrow(() -> new GroupException(GroupErrorCode.GROUP_NOT_FOUND));
+
         group.deactivate();
+        //TODO: 모임에 가입한 회원, 채팅방 등 사후처리 필요
+
         return group.getDisabled();
     }
 

--- a/backend/src/main/java/com/app/backend/domain/group/service/GroupService.java
+++ b/backend/src/main/java/com/app/backend/domain/group/service/GroupService.java
@@ -64,14 +64,14 @@ public class GroupService {
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(dto.getMaxRecruitCount())
                            .build();
-        groupRepository.save(group);
 
         //모임 채팅방 엔티티 생성
         ChatRoom chatRoom = ChatRoom.builder()
                                     .group(group)
                                     .build();
-        chatRoomRepository.save(chatRoom);
         group.setChatRoom(chatRoom);
+        chatRoomRepository.save(chatRoom);
+        groupRepository.save(group);
 
         //모임 멤버십 엔티티 생성(회원-모임 연결 테이블, 모임 관리자 권한(LEADER) 부여)
         GroupMembership groupMembership = GroupMembership.builder()

--- a/backend/src/test/java/com/app/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/controller/GroupControllerTest.java
@@ -20,6 +20,7 @@ import com.app.backend.domain.group.entity.Group;
 import com.app.backend.domain.group.entity.RecruitStatus;
 import com.app.backend.domain.group.exception.GroupException;
 import com.app.backend.domain.group.supporter.WebMvcTestSupporter;
+import com.app.backend.global.annotation.CustomWithMockUser;
 import com.app.backend.global.dto.response.ApiResponse;
 import com.app.backend.global.error.exception.GlobalErrorCode;
 import com.app.backend.global.util.ReflectionUtil;
@@ -58,10 +59,11 @@ class GroupControllerTest extends WebMvcTestSupporter {
         when(groupService.getGroup(anyLong())).thenReturn(response);
         when(groupService.getGroups()).thenReturn(responseList);
         when(groupService.modifyGroup(any(GroupRequest.Update.class))).thenReturn(response);
-        when(groupService.deleteGroup(anyLong())).thenReturn(true);
+        when(groupService.deleteGroup(anyLong(), anyLong())).thenReturn(true);
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[성공] 신규 모임 생성")
     void createGroup() throws Exception {
         //Given
@@ -93,6 +95,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[예외] 신규 모임 생성 요청 DTO에 올바르지 않은 값 존재 시")
     void createGroup_invalidValue() throws Exception {
         //Given
@@ -127,6 +130,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[성공] ID로 모임 단 건 조회")
     void getGroupById() throws Exception {
         //Given
@@ -149,6 +153,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[예외] 올바르지 않은 ID로 모임 단 건 조회 시도")
     void getGroupById_invalidId() throws Exception {
         //Given
@@ -173,6 +178,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[성공] 모임 목록 조회")
     void getGroups() throws Exception {
         //Given
@@ -195,6 +201,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[성공] 기존 모임 수정")
     void modifyGroup() throws Exception {
         //Given
@@ -227,6 +234,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[예외] 올바르지 않은 ID로 기존 모임 수정 시도")
     void modifyGroup_invalidId() throws Exception {
         //Given
@@ -263,6 +271,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[성공] 기존 모임 삭제(Soft Delete)")
     void deleteGroup() throws Exception {
         //Given
@@ -284,6 +293,7 @@ class GroupControllerTest extends WebMvcTestSupporter {
     }
 
     @Test
+    @CustomWithMockUser
     @DisplayName("[예외] 올바르지 않은 ID로 기존 모임 삭제 시도")
     void deleteGroup_invalidId() throws Exception {
         //Given

--- a/backend/src/test/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryTest.java
@@ -1,0 +1,1307 @@
+package com.app.backend.domain.group.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.app.backend.domain.group.entity.Group;
+import com.app.backend.domain.group.entity.GroupMembership;
+import com.app.backend.domain.group.entity.GroupMembershipId;
+import com.app.backend.domain.group.entity.GroupRole;
+import com.app.backend.domain.group.entity.MembershipStatus;
+import com.app.backend.domain.group.entity.RecruitStatus;
+import com.app.backend.domain.group.supporter.SpringBootTestSupporter;
+import com.app.backend.domain.member.entity.Member;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
+
+    @AfterEach
+    void afterEach() {
+        em.flush();
+        em.clear();
+    }
+
+    @Test
+    @DisplayName("[성공] GroupMembership 엔티티 저장")
+    void save() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId = member.getId();
+
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId = group.getId();
+
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .group(group)
+                                                         .member(member)
+                                                         .groupRole(GroupRole.PARTICIPANT)
+                                                         .build();
+        afterEach();
+
+        //When
+        groupMembershipRepository.save(groupMembership);
+        afterEach();
+
+        //Then
+        GroupMembershipId groupMembershipId = GroupMembershipId.builder()
+                                                               .memberId(memberId)
+                                                               .groupId(groupId)
+                                                               .build();
+
+        GroupMembership findGroupMembership = em.find(GroupMembership.class, groupMembershipId);
+
+        assertThat(findGroupMembership.getGroupId()).isEqualTo(groupId);
+        assertThat(findGroupMembership.getMemberId()).isEqualTo(memberId);
+        assertThat(findGroupMembership.getGroupRole()).isEqualTo(GroupRole.PARTICIPANT);
+        assertThat(findGroupMembership.getStatus()).isEqualTo(MembershipStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("[성공] ID로 GroupMembership 엔티티 조회")
+    void findById() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId = member.getId();
+
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId = group.getId();
+
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .group(group)
+                                                         .member(member)
+                                                         .groupRole(GroupRole.PARTICIPANT)
+                                                         .build();
+        em.persist(groupMembership);
+        afterEach();
+
+        GroupMembershipId groupMembershipId = GroupMembershipId.builder()
+                                                               .memberId(memberId)
+                                                               .groupId(groupId)
+                                                               .build();
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findById(groupMembershipId);
+
+        //Then
+        assertThat(opGroupMembership).isPresent();
+        assertThat(opGroupMembership.get().getMemberId()).isEqualTo(memberId);
+        assertThat(opGroupMembership.get().getGroupId()).isEqualTo(groupId);
+        assertThat(opGroupMembership.get().getGroupRole()).isEqualTo(GroupRole.PARTICIPANT);
+        assertThat(opGroupMembership.get().getStatus()).isEqualTo(MembershipStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 ID로 GroupMembership 엔티티 조회 시도")
+    void findById_unknownId() {
+        //Given
+        GroupMembershipId groupMembershipId = GroupMembershipId.builder()
+                                                               .memberId(1234567890L)
+                                                               .groupId(1234567890L)
+                                                               .build();
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findById(groupMembershipId);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID와 Member ID로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberId() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId = member.getId();
+
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId = group.getId();
+
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .group(group)
+                                                         .member(member)
+                                                         .groupRole(GroupRole.PARTICIPANT)
+                                                         .build();
+        em.persist(groupMembership);
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findByGroupIdAndMemberId(groupId,
+                                                                                                         memberId);
+
+        //Then
+        assertThat(opGroupMembership).isPresent();
+        assertThat(opGroupMembership.get().getMemberId()).isEqualTo(memberId);
+        assertThat(opGroupMembership.get().getGroupId()).isEqualTo(groupId);
+        assertThat(opGroupMembership.get().getGroupRole()).isEqualTo(GroupRole.PARTICIPANT);
+        assertThat(opGroupMembership.get().getStatus()).isEqualTo(MembershipStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("[실패] Member ID와 존재하지 않는 Group ID로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberId_unknownGroupId() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId       = member.getId();
+        Long unknownGroupId = 1234567890L;
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findByGroupIdAndMemberId(unknownGroupId,
+                                                                                                         memberId);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[실패] Group ID와 존재하지 않는 Member ID로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberId_unknownMemberId() {
+        //Given
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId         = group.getId();
+        Long unknownMemberId = 1234567890L;
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findByGroupIdAndMemberId(groupId,
+                                                                                                         unknownMemberId);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 Group ID와 Member ID로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberId_unknownGroupIdAndMemberId() {
+        //Given
+        Long unknownGroupId  = 1234567890L;
+        Long unknownMemberId = 1234567890L;
+
+        //When
+        Optional<GroupMembership> opGroupMembership = groupMembershipRepository.findByGroupIdAndMemberId(unknownGroupId,
+                                                                                                         unknownMemberId);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID와 Member ID, Disabled = false로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberIdAndDisabled() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId = member.getId();
+
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId = group.getId();
+
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .group(group)
+                                                         .member(member)
+                                                         .groupRole(GroupRole.PARTICIPANT)
+                                                         .build();
+        em.persist(groupMembership);
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(groupId,
+                                                                              memberId,
+                                                                              false);
+
+        //Then
+        assertThat(opGroupMembership).isPresent();
+        assertThat(opGroupMembership.get().getMemberId()).isEqualTo(memberId);
+        assertThat(opGroupMembership.get().getGroupId()).isEqualTo(groupId);
+        assertThat(opGroupMembership.get().getGroupRole()).isEqualTo(GroupRole.PARTICIPANT);
+        assertThat(opGroupMembership.get().getStatus()).isEqualTo(MembershipStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("[실패] Group ID와 Member ID, Disabled = true로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberIdAndDisabled_disabled() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId = member.getId();
+
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId = group.getId();
+
+        GroupMembership groupMembership = GroupMembership.builder()
+                                                         .group(group)
+                                                         .member(member)
+                                                         .groupRole(GroupRole.PARTICIPANT)
+                                                         .build();
+        em.persist(groupMembership);
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(groupId,
+                                                                              memberId,
+                                                                              true);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[실패] Member ID와 존재하지 않는 Group ID, Disabled = false로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberIdAndDisabled_unknownGroupId() {
+        //Given
+        Member member = Member.builder()
+                              .username("testUsername")
+                              .password("testPassword")
+                              .nickname("testNickname")
+                              .build();
+        em.persist(member);
+        Long memberId       = member.getId();
+        Long unknownGroupId = 1234567890L;
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(unknownGroupId,
+                                                                              memberId,
+                                                                              false);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[실패] Group ID와 존재하지 않는 Member ID, Disabled = false로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberIdAndDisabled_unknownMemberId() {
+        //Given
+        Group group = Group.builder()
+                           .name("test")
+                           .province("test province")
+                           .city("test city")
+                           .town("test town")
+                           .description("test description")
+                           .recruitStatus(RecruitStatus.RECRUITING)
+                           .maxRecruitCount(10)
+                           .build();
+        em.persist(group);
+        Long groupId         = group.getId();
+        Long unknownMemberId = 1234567890L;
+        afterEach();
+
+        //When
+        Optional<GroupMembership> opGroupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(groupId,
+                                                                              unknownMemberId,
+                                                                              false);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 Group ID와 Member ID, Disabled = false로 GroupMembership 엔티티 조회")
+    void findByGroupIdAndMemberIdAndDisabled_unknownGroupIdAndMemberId() {
+        //Given
+        Long unknownGroupId  = 1234567890L;
+        Long unknownMemberId = 1234567890L;
+
+        //When
+        Optional<GroupMembership> opGroupMembership =
+                groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(unknownGroupId,
+                                                                              unknownMemberId,
+                                                                              false);
+
+        //Then
+        assertThat(opGroupMembership).isNotPresent();
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupId() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByGroupId(groupId);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupId().equals(groupId))
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID와 Disabled = false로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupIdAndDisabled() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByGroupIdAndDisabled(groupId,
+                                                                                                           false);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupId().equals(groupId)
+                                                                      && !groupMembership.getDisabled())
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] Group ID와 Disabled = true로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupIdAndDisabled_disabled() {
+        //Given
+        int   size  = 20;
+        int   j     = 0;
+        Group group = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByGroupIdAndDisabled(groupId,
+                                                                                                           false);
+
+        //Then
+        assertThat(findGroupMemberships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] Member ID로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberId() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByMemberId(memberId);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getMemberId().equals(memberId))
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] Member ID와 Disabled = false로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberIdAndDisabled() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByMemberIdAndDisabled(memberId,
+                                                                                                            false);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getMemberId().equals(memberId)
+                                                                      && !groupMembership.getDisabled())
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] Member ID와 Disabled = true로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberIdAndDisabled_disabled() {
+        //Given
+        int   size  = 20;
+        int   j     = 0;
+        Group group = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByMemberIdAndDisabled(memberId,
+                                                                                                            false);
+
+        //Then
+        assertThat(findGroupMemberships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 모임 권한으로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupRole() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByGroupRole(GroupRole.PARTICIPANT);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupRole()
+                                                                                     .equals(GroupRole.PARTICIPANT))
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] 모임 권한과 Disabled = false로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupRoleAndDisabled() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByGroupRoleAndDisabled(GroupRole.PARTICIPANT, false);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupRole()
+                                                                                     .equals(GroupRole.PARTICIPANT)
+                                                                      && !groupMembership.getDisabled())
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] 모임 권한과 Disabled = true로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupRoleAndDisabled_disabled() {
+        //Given
+        int   size  = 20;
+        int   j     = 0;
+        Group group = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+        }
+        afterEach();
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByGroupRoleAndDisabled(GroupRole.PARTICIPANT, true);
+
+        //Then
+        assertThat(findGroupMemberships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID와 모임 권한으로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupIdAndGroupRole() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByGroupIdAndGroupRole(groupId,
+                                                                                                            GroupRole.PARTICIPANT);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupId().equals(groupId)
+                                                                      && groupMembership.getGroupRole()
+                                                                                        .equals(GroupRole.PARTICIPANT))
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] Group ID와 모임 권한, Disabled = false로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupIdAndGroupRoleAndDisabled() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByGroupIdAndGroupRoleAndDisabled(groupId,
+                                                                                  GroupRole.PARTICIPANT,
+                                                                                  false);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getGroupId().equals(groupId)
+                                                                      && groupMembership.getGroupRole()
+                                                                                        .equals(GroupRole.PARTICIPANT)
+                                                                      && !groupMembership.getDisabled())
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] Group ID와 모임 권한, Disabled = true로 GroupMembership 엔티티 목록 조회")
+    void findAllByGroupIdAndGroupRoleAndDisabled_disabled() {
+        //Given
+        int   size  = 20;
+        int   j     = 0;
+        Group group = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+        }
+        afterEach();
+
+        Long groupId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByGroupIdAndGroupRoleAndDisabled(groupId,
+                                                                                  GroupRole.PARTICIPANT,
+                                                                                  true);
+
+        //Then
+        assertThat(findGroupMemberships).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] Member ID와 모임 권한으로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberIdAndGroupRole() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships = groupMembershipRepository.findAllByMemberIdAndGroupRole(memberId,
+                                                                                                             GroupRole.PARTICIPANT);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getMemberId().equals(memberId)
+                                                                      && groupMembership.getGroupRole()
+                                                                                        .equals(GroupRole.PARTICIPANT))
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[성공] Member ID와 모임 권한, Disabled = false로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberIdAndGroupRoleAndDisabled() {
+        //Given
+        int                   size             = 20;
+        List<GroupMembership> groupMemberships = new ArrayList<>();
+        int                   j                = 0;
+        Group                 group            = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+            groupMemberships.add(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByMemberIdAndGroupRoleAndDisabled(memberId,
+                                                                                   GroupRole.PARTICIPANT,
+                                                                                   false);
+
+        //Then
+        groupMemberships = groupMemberships.stream()
+                                           .filter(groupMembership -> groupMembership.getMemberId().equals(memberId)
+                                                                      && groupMembership.getGroupRole()
+                                                                                        .equals(GroupRole.PARTICIPANT)
+                                                                      && !groupMembership.getDisabled())
+                                           .toList();
+
+        assertThat(findGroupMemberships).hasSize(groupMemberships.size());
+        for (int i = 0; i < groupMemberships.size(); i++) {
+            GroupMembership groupMembership     = groupMemberships.get(i);
+            GroupMembership findGroupMembership = findGroupMemberships.get(i);
+
+            assertThat(findGroupMembership.getGroupId()).isEqualTo(groupMembership.getGroupId());
+            assertThat(findGroupMembership.getMemberId()).isEqualTo(groupMembership.getMemberId());
+            assertThat(findGroupMembership.getGroupRole()).isEqualTo(groupMembership.getGroupRole());
+            assertThat(findGroupMembership.getStatus()).isEqualTo(groupMembership.getStatus());
+        }
+    }
+
+    @Test
+    @DisplayName("[실패] Member ID와 모임 권한, Disabled = true로 GroupMembership 엔티티 목록 조회")
+    void findAllByMemberIdAndGroupRoleAndDisabled_disabled() {
+        //Given
+        int   size  = 20;
+        int   j     = 0;
+        Group group = null;
+
+        for (int i = 0; i < size; i++) {
+            Member member = Member.builder()
+                                  .username("testUsername%d".formatted(i))
+                                  .password("testPassword%d".formatted(i))
+                                  .nickname("testNickname%d".formatted(i))
+                                  .build();
+            em.persist(member);
+
+            if (j % 5 == 0) {
+                group = Group.builder()
+                             .name("test%d".formatted(j))
+                             .province("test province%d".formatted(j))
+                             .city("test city%d".formatted(j))
+                             .town("test town%d".formatted(j))
+                             .description("test description%d".formatted(j))
+                             .recruitStatus(RecruitStatus.RECRUITING)
+                             .maxRecruitCount(10)
+                             .build();
+                em.persist(group);
+                j += 1;
+            }
+
+            GroupMembership groupMembership = GroupMembership.builder()
+                                                             .group(group)
+                                                             .member(member)
+                                                             .groupRole(GroupRole.PARTICIPANT)
+                                                             .build();
+            em.persist(groupMembership);
+        }
+        afterEach();
+
+        Long memberId = 3L;
+
+        //When
+        List<GroupMembership> findGroupMemberships =
+                groupMembershipRepository.findAllByMemberIdAndGroupRoleAndDisabled(memberId,
+                                                                                   GroupRole.PARTICIPANT,
+                                                                                   true);
+
+        //Then
+        assertThat(findGroupMemberships).isEmpty();
+    }
+
+}

--- a/backend/src/test/java/com/app/backend/domain/group/supporter/SpringBootTestSupporter.java
+++ b/backend/src/test/java/com/app/backend/domain/group/supporter/SpringBootTestSupporter.java
@@ -1,7 +1,10 @@
 package com.app.backend.domain.group.supporter;
 
+import com.app.backend.domain.chat.room.repository.ChatRoomRepository;
+import com.app.backend.domain.group.repository.GroupMembershipRepository;
 import com.app.backend.domain.group.repository.GroupRepository;
 import com.app.backend.domain.group.service.GroupService;
+import com.app.backend.domain.member.repository.MemberRepository;
 import jakarta.persistence.EntityManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +19,15 @@ public abstract class SpringBootTestSupporter {
 
     @Autowired
     protected GroupRepository groupRepository;
+
+    @Autowired
+    protected GroupMembershipRepository groupMembershipRepository;
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected ChatRoomRepository chatRoomRepository;
 
     @Autowired
     protected GroupService groupService;

--- a/backend/src/test/java/com/app/backend/global/annotation/CustomWithMockUser.java
+++ b/backend/src/test/java/com/app/backend/global/annotation/CustomWithMockUser.java
@@ -1,0 +1,22 @@
+package com.app.backend.global.annotation;
+
+import com.app.backend.global.security.CustomWithSecurityContextFactory;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = CustomWithSecurityContextFactory.class)
+public @interface CustomWithMockUser {
+
+    long id() default 1L;
+
+    String username() default "testUsername";
+
+    String password() default "testPassword";
+
+    String nickname() default "testNickname";
+
+    String role() default "ROLE_USER";
+
+}

--- a/backend/src/test/java/com/app/backend/global/security/CustomWithSecurityContextFactory.java
+++ b/backend/src/test/java/com/app/backend/global/security/CustomWithSecurityContextFactory.java
@@ -1,0 +1,31 @@
+package com.app.backend.global.security;
+
+import com.app.backend.domain.member.entity.Member;
+import com.app.backend.domain.member.entity.MemberDetails;
+import com.app.backend.global.annotation.CustomWithMockUser;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class CustomWithSecurityContextFactory implements WithSecurityContextFactory<CustomWithMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(CustomWithMockUser annotation) {
+        SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+
+        MemberDetails memberDetails = new MemberDetails(Member.builder()
+                                                              .id(annotation.id())
+                                                              .username(annotation.username())
+                                                              .password(annotation.password())
+                                                              .nickname(annotation.nickname())
+                                                              .role(annotation.role())
+                                                              .build());
+        securityContext.setAuthentication(
+                new UsernamePasswordAuthenticationToken(memberDetails, null, memberDetails.getAuthorities())
+        );
+
+        return securityContext;
+    }
+
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 모임(Group) - 회원(Member) 간 연관관계를 위한 중간 엔티티 구현
  - GroupMembership 엔티티: 복합키 활용(Member ID + Group ID)
  - 리포지토리 생성 및 테스트 완료
- GroupService/GroupController 내 회원 검증 로직 추가
  - 시큐리티 내 인증 객체 활용
- 연관관계 추가에 따른 서비스 로직 수정
  - 모임(Group) - 채팅방(ChatRoom) 일대일 관계 적용, 모임 생성 시 모임과 연관관계를 갖는 채팅방 생성 및 연관관계 설정
  - 모임 생성 시 모임 생성 로직을 호출한 회원에 대하여 모임 관리자(LEADER) 권한 부여
  - 모임 수정/삭제 시 회원 ID를 추가 적용하여 GroupMembership 엔티티를 호출하여 권한 여부 확인 로직 추가
  - GroupService 테스트 코드 수정
- 테스트 시 활용할 시큐리티 인증 관련 클래스 추가
  - CustomWithMockUser 어노테이션
  - CustomWithSecurityContextFactory 추가

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->