### PR TITLE
[Feature]: [BE] 모임 신청 승인/거절, 모임 탈퇴, 모임 내 권한 변경 API 추가

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/group/constant/GroupMessageConstant.java
+++ b/backend/src/main/java/com/app/backend/domain/group/constant/GroupMessageConstant.java
@@ -1,9 +1,13 @@
 package com.app.backend.domain.group.constant;
 
 public abstract class GroupMessageConstant {
-    public static final String CREATE_GROUP_SUCCESS = "모임이 성공적으로 생성되었습니다.";
-    public static final String READ_GROUP_SUCCESS   = "모임이 성공적으로 조회되었습니다.";
-    public static final String READ_GROUPS_SUCCESS  = "모임 목록이 성공적으로 조회되었습니다.";
-    public static final String UPDATE_GROUP_SUCCESS = "모임이 성공적으로 수정되었습니다.";
-    public static final String DELETE_GROUP_SUCCESS = "모임이 성공적으로 삭제되었습니다.";
+    public static final String CREATE_GROUP_SUCCESS      = "모임이 성공적으로 생성되었습니다.";
+    public static final String READ_GROUP_SUCCESS        = "모임이 성공적으로 조회되었습니다.";
+    public static final String READ_GROUPS_SUCCESS       = "모임 목록이 성공적으로 조회되었습니다.";
+    public static final String UPDATE_GROUP_SUCCESS      = "모임이 성공적으로 수정되었습니다.";
+    public static final String DELETE_GROUP_SUCCESS      = "모임이 성공적으로 삭제되었습니다.";
+    public static final String LEAVE_GROUP_SUCCESS       = "모임에서 성공적으로 탈퇴했습니다.";
+    public static final String APPROVE_JOINING_SUCCESS   = "모임 신청을 승인했습니다.";
+    public static final String REJECT_JOINING_SUCCESS    = "모임 신청을 거절했습니다.";
+    public static final String MODIFY_GROUP_ROLE_SUCCESS = "모임 내 회원 권한이 성공적으로 변경되었습니다.";
 }

--- a/backend/src/main/java/com/app/backend/domain/group/dto/request/GroupRequest.java
+++ b/backend/src/main/java/com/app/backend/domain/group/dto/request/GroupRequest.java
@@ -18,7 +18,6 @@ public class GroupRequest {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Create {
-        private Long    memberId;
         @NotNull
         @NotBlank
         private String  name;
@@ -38,6 +37,7 @@ public class GroupRequest {
         @Min(1)
         private Integer maxRecruitCount;
         @NotNull
+        @NotBlank
         private String  categoryName;
     }
 
@@ -47,8 +47,6 @@ public class GroupRequest {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Update {
-        private Long    groupId;
-        private Long    memberId;
         @NotNull
         @NotBlank
         private String  name;
@@ -71,7 +69,32 @@ public class GroupRequest {
         @Min(1)
         private Integer maxRecruitCount;
         @NotNull
+        @NotBlank
         private String  categoryName;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ApproveJoining {
+        @NotNull
+        @Min(1)
+        private Long    memberId;
+        @NotNull
+        private Boolean isAccept;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class Permission {
+        @NotNull
+        @Min(1)
+        private Long memberId;
     }
 
 }

--- a/backend/src/test/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/repository/GroupMembershipRepositoryTest.java
@@ -2,6 +2,7 @@ package com.app.backend.domain.group.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.app.backend.domain.category.entity.Category;
 import com.app.backend.domain.group.entity.Group;
 import com.app.backend.domain.group.entity.GroupMembership;
 import com.app.backend.domain.group.entity.GroupMembershipId;
@@ -15,12 +16,23 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
+
+    private Category category;
+
+    @BeforeEach
+    void beforeEach() {
+        category = Category.builder()
+                           .name("category")
+                           .build();
+        em.persist(category);
+    }
 
     @AfterEach
     void afterEach() {
@@ -48,6 +60,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -97,6 +110,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -161,6 +175,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -219,6 +234,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId         = group.getId();
@@ -268,6 +284,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -314,6 +331,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -372,6 +390,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId         = group.getId();
@@ -431,6 +450,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -494,6 +514,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -558,6 +579,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -608,6 +630,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -671,6 +694,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -735,6 +759,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -785,6 +810,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -848,6 +874,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -911,6 +938,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -959,6 +987,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1025,6 +1054,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1093,6 +1123,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1145,6 +1176,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1211,6 +1243,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1279,6 +1312,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1325,6 +1359,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -1364,6 +1399,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -1409,6 +1445,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1466,6 +1503,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1528,6 +1566,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1594,6 +1633,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1662,6 +1702,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1728,6 +1769,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;
@@ -1796,6 +1838,7 @@ class GroupMembershipRepositoryTest extends SpringBootTestSupporter {
                              .description("test description%d".formatted(j))
                              .recruitStatus(RecruitStatus.RECRUITING)
                              .maxRecruitCount(10)
+                             .category(category)
                              .build();
                 em.persist(group);
                 j += 1;

--- a/backend/src/test/java/com/app/backend/domain/group/repository/GroupRepositoryTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/repository/GroupRepositoryTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
@@ -19,6 +20,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 class GroupRepositoryTest extends SpringBootTestSupporter {
+
+    private Category category;
+
+    @BeforeEach
+    void beforeEach() {
+        category = Category.builder()
+                           .name("category")
+                           .build();
+        em.persist(category);
+    }
 
     @AfterEach
     void afterEach() {
@@ -38,6 +49,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
 
         //When
@@ -69,6 +81,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();
@@ -114,6 +127,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();
@@ -146,6 +160,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();
@@ -186,6 +201,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -225,6 +241,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -252,6 +269,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -295,6 +313,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -323,6 +342,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -366,6 +386,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -394,6 +415,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -423,6 +445,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -468,6 +491,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -499,6 +523,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             em.persist(group);
         }
@@ -531,6 +556,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -579,6 +605,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -629,6 +656,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -679,6 +707,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                                .description("test description%d".formatted(i))
                                .recruitStatus(RecruitStatus.RECRUITING)
                                .maxRecruitCount(10)
+                               .category(category)
                                .build();
             groups.add(group);
             em.persist(group);
@@ -721,10 +750,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명으로 Group 엔티티 목록 조회")
     void findAllListByCategory_Name() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -770,10 +795,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명으로 Group 엔티티 페이징 목록 조회")
     void findAllPageByCategory_Name() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -821,10 +842,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명과 Disabled로 Group 엔티티 목록 조회")
     void findAllListByCategory_NameAndDisabled() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -871,10 +888,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명과 Disabled로 Group 엔티티 페이징 목록 조회")
     void findAllPageByCategory_NameAndDisabled() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -925,10 +938,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명, 모임 이름과 Disabled로 Group 엔티티 목록 조회")
     void findAllListByCategory_NameAndNameContainingAndDisabled() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -980,10 +989,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명, 모임 이름과 Disabled로 Group 엔티티 페이징 목록 조회")
     void findAllPageByCategory_NameAndNameContainingAndDisabled() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -1038,10 +1043,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명, 모임 이름과 상세 주소, Disabled로 Group 엔티티 목록 조회")
     void findAllListByCategoryAndNameContainingAndRegion() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -1101,10 +1102,6 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
     @DisplayName("[성공] 카테고리명, 모임 이름과 상세 주소, Disabled로 Group 엔티티 페이징 목록 조회")
     void findAllPageByCategoryAndNameContainingAndRegion() {
         //Given
-        Category category = Category.builder()
-                                    .name("category")
-                                    .build();
-        em.persist(category);
         String categoryName = category.getName();
 
         int         size   = 20;
@@ -1175,6 +1172,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();
@@ -1222,6 +1220,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();
@@ -1248,6 +1247,7 @@ class GroupRepositoryTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long id = group.getId();

--- a/backend/src/test/java/com/app/backend/domain/group/service/GroupMembershipServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/service/GroupMembershipServiceTest.java
@@ -3,6 +3,7 @@ package com.app.backend.domain.group.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.app.backend.domain.category.entity.Category;
 import com.app.backend.domain.group.entity.Group;
 import com.app.backend.domain.group.entity.GroupMembership;
 import com.app.backend.domain.group.entity.GroupMembershipId;
@@ -16,12 +17,23 @@ import com.app.backend.domain.group.exception.GroupMembershipException;
 import com.app.backend.domain.group.supporter.SpringBootTestSupporter;
 import com.app.backend.domain.member.entity.Member;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 class GroupMembershipServiceTest extends SpringBootTestSupporter {
+
+    private Category category;
+
+    @BeforeEach
+    void beforeEach() {
+        category = Category.builder()
+                           .name("category")
+                           .build();
+        em.persist(category);
+    }
 
     @AfterEach
     void afterEach() {
@@ -56,6 +68,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -115,6 +128,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -207,6 +221,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -265,6 +280,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(1)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -321,6 +337,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -377,6 +394,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -435,6 +453,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -528,6 +547,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -588,6 +608,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -643,6 +664,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -703,6 +725,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -758,6 +781,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -836,6 +860,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();
@@ -873,6 +898,7 @@ class GroupMembershipServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();

--- a/backend/src/test/java/com/app/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/service/GroupServiceTest.java
@@ -64,10 +64,9 @@ class GroupServiceTest extends SpringBootTestSupporter {
                                                          .maxRecruitCount(10)
                                                          .categoryName(categoryName)
                                                          .build();
-        request.setMemberId(memberId);
 
         //When
-        Long id = groupService.createGroup(request);
+        Long id = groupService.createGroup(memberId, request);
         afterEach();
 
         //Then
@@ -629,11 +628,9 @@ class GroupServiceTest extends SpringBootTestSupporter {
                                                         .maxRecruitCount(20)
                                                         .categoryName(newCategoryName)
                                                         .build();
-        update.setGroupId(groupId);
-        update.setMemberId(memberId);
 
         //When
-        GroupResponse.Detail response = groupService.modifyGroup(update);
+        GroupResponse.Detail response = groupService.modifyGroup(groupId, memberId, update);
 
         //Then
         assertThat(response.getName()).isNotEqualTo(group.getName());
@@ -661,8 +658,6 @@ class GroupServiceTest extends SpringBootTestSupporter {
         Long unknownId = 1234567890L;
 
         GroupRequest.Update update = GroupRequest.Update.builder()
-                                                        .groupId(unknownId)
-                                                        .memberId(unknownId)
                                                         .name("new test")
                                                         .province("new test province")
                                                         .city("new test city")
@@ -677,7 +672,7 @@ class GroupServiceTest extends SpringBootTestSupporter {
         //Then
         GroupMembershipErrorCode errorCode = GroupMembershipErrorCode.GROUP_MEMBERSHIP_NOT_FOUND;
 
-        assertThatThrownBy(() -> groupService.modifyGroup(update))
+        assertThatThrownBy(() -> groupService.modifyGroup(unknownId, unknownId, update))
                 .isInstanceOf(GroupMembershipException.class)
                 .hasFieldOrPropertyWithValue("domainErrorCode", errorCode)
                 .hasMessage(errorCode.getMessage());

--- a/backend/src/test/java/com/app/backend/domain/group/service/GroupServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/service/GroupServiceTest.java
@@ -690,6 +690,11 @@ class GroupServiceTest extends SpringBootTestSupporter {
         em.persist(member);
         Long memberId = member.getId();
 
+        Category category = Category.builder()
+                                    .name("category")
+                                    .build();
+        em.persist(category);
+
         Group group = Group.builder()
                            .name("test")
                            .province("test province")
@@ -698,6 +703,7 @@ class GroupServiceTest extends SpringBootTestSupporter {
                            .description("test description")
                            .recruitStatus(RecruitStatus.RECRUITING)
                            .maxRecruitCount(10)
+                           .category(category)
                            .build();
         em.persist(group);
         Long groupId = group.getId();

--- a/backend/src/test/java/com/app/backend/domain/group/supporter/WebMvcTestSupporter.java
+++ b/backend/src/test/java/com/app/backend/domain/group/supporter/WebMvcTestSupporter.java
@@ -1,5 +1,6 @@
 package com.app.backend.domain.group.supporter;
 
+import com.app.backend.domain.group.service.GroupMembershipService;
 import com.app.backend.domain.group.service.GroupService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,5 +25,8 @@ public abstract class WebMvcTestSupporter {
 
     @MockitoBean
     protected GroupService groupService;
+
+    @MockitoBean
+    protected GroupMembershipService groupMembershipService;
 
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- API 명세 기반 컨트롤러 로직 추가
  - 모임 신청 승인/거절: 모임 관리자가 모임 신청 회원을 가입 승인 또는 거절
  - 모임 탈퇴: 모임에 가입된 회원이 모임에서 탈퇴
  - 모임 내 권한 변경: 모임 관리자가 모임 내 회원의 권한을 변경(관리자 <-> 참여자)
- 테스트 코드 추가
- 모임-카테고리 간 연관관계 설정 관련 테스트 코드 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->