### PR TITLE
[Feature]: [BE] groupMembership 엔티티 생성

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/meetingApplication/controller/MeetingApplicationController.java
+++ b/backend/src/main/java/com/app/backend/domain/meetingApplication/controller/MeetingApplicationController.java
@@ -34,6 +34,8 @@ public class MeetingApplicationController {
 		@RequestBody MeetingApplicationReqBody request,
 		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
+		meetingApplicationService.validateGroupMemberLimit(groupId); // 인원 제한 검증
+
 		MeetingApplication meetingApplication = meetingApplicationService.create(groupId, request, memberDetails.getId());
 
 		MeetingApplicationDto meetingApplicationDto = MeetingApplicationDto.from(meetingApplication);

--- a/backend/src/main/java/com/app/backend/domain/meetingApplication/exception/MeetingApplicationErrorCode.java
+++ b/backend/src/main/java/com/app/backend/domain/meetingApplication/exception/MeetingApplicationErrorCode.java
@@ -16,7 +16,8 @@ public enum MeetingApplicationErrorCode implements DomainErrorCode {
 	GROUP_MEMBER_LIMIT_EXCEEDED(HttpStatus.CONFLICT, "MA003", "그룹 정원이 초과되었습니다."),
 	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "MA004", "조회 권한이 없습니다."),
 	MEMBER_NOT_FOUND_IN_GROUP(HttpStatus.NOT_FOUND, "MA005", "그룹에 해당 멤버가 없습니다."),
-	MEETING_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "MA005", "해당 id의 meeting application은 존재하지 않습니다.");
+	MEETING_APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "MA005", "해당 id의 meeting application은 존재하지 않습니다."),
+	ALREADY_IN_GROUP(HttpStatus.CONFLICT, "MA006", "이미 가입된 회원입니다.");
 
 	private final HttpStatus status;
 	private final String code;

--- a/backend/src/main/java/com/app/backend/domain/meetingApplication/repository/MeetingApplicationRepository.java
+++ b/backend/src/main/java/com/app/backend/domain/meetingApplication/repository/MeetingApplicationRepository.java
@@ -8,9 +8,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.app.backend.domain.meetingApplication.entity.MeetingApplication;
 
 public interface MeetingApplicationRepository extends JpaRepository<MeetingApplication, Long> {
-	List<MeetingApplication> findByGroupId(Long id);
 
 	List<MeetingApplication> findByGroupIdAndDisabled(Long groupId, boolean disabled);
 
 	Optional<MeetingApplication> findByGroupIdAndIdAndDisabled(Long groupId, Long meetingApplicationId, boolean disabled);
+
+	Optional<MeetingApplication> findByIdAndDisabled(Long id, boolean disabled);
 }

--- a/backend/src/main/java/com/app/backend/domain/meetingApplication/service/MeetingApplicationService.java
+++ b/backend/src/main/java/com/app/backend/domain/meetingApplication/service/MeetingApplicationService.java
@@ -107,7 +107,7 @@ public class MeetingApplicationService {
 		return MeetingApplicationDto.from(meetingApplication);
 	}
 
-	// 검증 메서드
+	// 인원 제한 검증 메서드
 	public void validateGroupMemberLimit(Long groupId) {
 		Group group = groupRepository.findByIdAndDisabled(groupId, false)
 			.orElseThrow(() -> new MeetingApplicationException(MeetingApplicationErrorCode.GROUP_NOT_FOUND));

--- a/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationControllerTest/MeetingApplicationControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationControllerTest/MeetingApplicationControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import com.app.backend.domain.category.entity.Category;
+import com.app.backend.domain.category.repository.CategoryRepository;
 import com.app.backend.domain.group.entity.Group;
 import com.app.backend.domain.group.entity.GroupMembership;
 import com.app.backend.domain.group.entity.GroupRole;
@@ -59,6 +61,9 @@ public class MeetingApplicationControllerTest {
 	@Autowired
 	private MeetingApplicationRepository meetingApplicationRepository;
 
+	@Autowired
+	private CategoryRepository categoryRepository;
+
 	@MockitoBean
 	private MeetingApplicationService meetingApplicationService;
 
@@ -67,9 +72,21 @@ public class MeetingApplicationControllerTest {
 
 	private Group group;
 	private Member member;
+	private Category category;
 
 	@BeforeEach
 	void setup() {
+		// repository 초기화
+		meetingApplicationRepository.deleteAll();
+		groupMembershipRepository.deleteAll();
+		groupRepository.deleteAll();
+		categoryRepository.deleteAll();
+		memberRepository.deleteAll();
+
+		category = categoryRepository.save(Category.builder()
+			.name("category")
+			.build());
+
 		group = groupRepository.save(Group.builder()
 			.name("test group")
 			.province("test province")
@@ -78,6 +95,7 @@ public class MeetingApplicationControllerTest {
 			.description("test description")
 			.recruitStatus(RecruitStatus.RECRUITING)
 			.maxRecruitCount(10)
+			.category(category)
 			.build());
 
 		member = Member.builder()
@@ -139,6 +157,7 @@ public class MeetingApplicationControllerTest {
 			.description("test description")
 			.recruitStatus(RecruitStatus.RECRUITING)
 			.maxRecruitCount(1)
+			.category(category)
 			.build();
 		groupRepository.save(oneMemberGroup);  // 그룹 저장
 

--- a/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationControllerTest/MeetingApplicationControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationControllerTest/MeetingApplicationControllerTest.java
@@ -146,7 +146,7 @@ public class MeetingApplicationControllerTest {
 		groupMembershipRepository.save(GroupMembership.builder()
 			.group(oneMemberGroup)  // 정원 1명인 그룹에 멤버 추가
 			.member(member)
-			.groupRole(GroupRole.LEADER)  // 그룹 역할 LEADER로 설정
+			.groupRole(GroupRole.LEADER)  // status APPROVED로 저장됨
 			.build());
 
 		// 새로운 회원을 만들고 저장
@@ -158,14 +158,12 @@ public class MeetingApplicationControllerTest {
 			.build();
 		memberRepository.save(newMember);
 
-		// 신청 폼 데이터
 		MeetingApplicationReqBody request = new MeetingApplicationReqBody("Test Application");
 
 		// 정원 초과로 예외 발생
 		given(meetingApplicationService.create(oneMemberGroup.getId(), request, newMember.getId()))
 			.willThrow(new MeetingApplicationException(MeetingApplicationErrorCode.GROUP_MEMBER_LIMIT_EXCEEDED));
 
-		// 인증된 사용자 설정
 		MemberDetails mockUser = new MemberDetails(newMember);
 
 		// When & Then

--- a/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationServiceTest/MeetingApplicationServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationServiceTest/MeetingApplicationServiceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import com.app.backend.domain.category.entity.Category;
+import com.app.backend.domain.category.repository.CategoryRepository;
 import com.app.backend.domain.group.entity.Group;
 import com.app.backend.domain.group.entity.GroupMembership;
 import com.app.backend.domain.group.entity.GroupRole;
@@ -45,11 +47,26 @@ public class MeetingApplicationServiceTest {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	@Autowired
+	private CategoryRepository categoryRepository;
+
 	private Group group;
 	private Member member;
+	private Category category;
 
 	@BeforeEach
 	void setUp() {
+		// repository 초기화
+		meetingApplicationRepository.deleteAll();
+		groupMembershipRepository.deleteAll();
+		groupRepository.deleteAll();
+		categoryRepository.deleteAll();
+		memberRepository.deleteAll();
+
+		category = categoryRepository.save(Category.builder()
+			.name("category")
+			.build());
+
 		group = groupRepository.save(Group.builder()
 			.name("test group")
 			.province("test province")
@@ -58,6 +75,7 @@ public class MeetingApplicationServiceTest {
 			.description("test description")
 			.recruitStatus(RecruitStatus.RECRUITING)
 			.maxRecruitCount(10)
+			.category(category)
 			.build());
 
 		member = memberRepository.save(Member.builder()
@@ -79,6 +97,7 @@ public class MeetingApplicationServiceTest {
 			.description("test description")
 			.recruitStatus(RecruitStatus.RECRUITING)
 			.maxRecruitCount(1)
+			.category(category)
 			.build());
 
 		Member member1 = memberRepository.save(Member.builder()

--- a/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationServiceTest/MeetingApplicationServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/meetingApplication/meetingApplicationServiceTest/MeetingApplicationServiceTest.java
@@ -3,7 +3,9 @@ package com.app.backend.domain.meetingApplication.meetingApplicationServiceTest;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.util.List;
+import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,18 +45,40 @@ public class MeetingApplicationServiceTest {
 	@Autowired
 	private MemberRepository memberRepository;
 
-	@Test
-	@DisplayName("Fail : 그룹 정원 초과 시 예외 처리")
-	void t1() {
-		// Given
-		Group group = groupRepository.save(Group.builder()
+	private Group group;
+	private Member member;
+
+	@BeforeEach
+	void setUp() {
+		group = groupRepository.save(Group.builder()
 			.name("test group")
 			.province("test province")
 			.city("test city")
 			.town("test town")
 			.description("test description")
 			.recruitStatus(RecruitStatus.RECRUITING)
-			.maxRecruitCount(1)  // 정원을 1로 설정
+			.maxRecruitCount(10)
+			.build());
+
+		member = memberRepository.save(Member.builder()
+			.username("testUser")
+			.nickname("nickname")
+			.role("USER")
+			.disabled(false)
+			.build());
+	}
+
+	@Test
+	@DisplayName("Fail : 그룹 정원 초과 시 예외 처리")
+	void t1() {
+		Group limitedGroup = groupRepository.save(Group.builder()
+			.name("test limited group")
+			.province("test province")
+			.city("test city")
+			.town("test town")
+			.description("test description")
+			.recruitStatus(RecruitStatus.RECRUITING)
+			.maxRecruitCount(1)
 			.build());
 
 		Member member1 = memberRepository.save(Member.builder()
@@ -71,30 +95,113 @@ public class MeetingApplicationServiceTest {
 			.disabled(false)
 			.build());
 
-		// 1명만 그룹에 추가
 		groupMembershipRepository.save(GroupMembership.builder()
-			.group(group)
+			.group(limitedGroup)
 			.member(member1)
 			.groupRole(GroupRole.LEADER)
 			.build());
 
-
 		MeetingApplicationReqBody request = new MeetingApplicationReqBody("Test Application");
 
-		// When & Then
-		assertThatThrownBy(() -> meetingApplicationService.create(group.getId(), request, member2.getId()))
+		assertThatThrownBy(() -> {
+			meetingApplicationService.validateGroupMemberLimit(limitedGroup.getId());
+			meetingApplicationService.create(limitedGroup.getId(), request, member2.getId());
+		})
 			.isInstanceOf(MeetingApplicationException.class)
 			.hasFieldOrPropertyWithValue("domainErrorCode", MeetingApplicationErrorCode.GROUP_MEMBER_LIMIT_EXCEEDED)
 			.hasMessage("그룹 정원이 초과되었습니다.");
+	}
 
-		// MeetingApplication 저장 X
-		List<MeetingApplication> applications = meetingApplicationRepository.findByGroupId(group.getId());
+	@Test
+	@DisplayName("Success : 기존 그룹 멤버십이 REJECTED 상태인 회원이 신청하면 PENDING으로 변경되고 MeetingApplication이 저장")
+	void t2() {
+		GroupMembership rejectedMembership = groupMembershipRepository.save(GroupMembership.builder()
+			.group(group)
+			.member(member)
+			.groupRole(GroupRole.PARTICIPANT)
+			.build());
+
+		rejectedMembership.modifyStatus(MembershipStatus.REJECTED);
+		groupMembershipRepository.save(rejectedMembership);
+
+		MeetingApplicationReqBody request = new MeetingApplicationReqBody("Test Application");
+		MeetingApplication savedApplication = meetingApplicationService.create(group.getId(), request, member.getId());
+
+		GroupMembership updatedMembership = groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(group.getId(), member.getId(), false)
+			.orElseThrow();
+		assertThat(updatedMembership.getStatus()).isEqualTo(MembershipStatus.PENDING);
+	}
+
+	@Test
+	@DisplayName("Success : 기존 그룹 멤버십이 LEAVE 상태인 회원이 신청하면 PENDING으로 변경되고 MeetingApplication이 저장")
+	void t3() {
+		// Given
+		GroupMembership leaveMembership = groupMembershipRepository.save(GroupMembership.builder()
+			.group(group)
+			.member(member)
+			.groupRole(GroupRole.PARTICIPANT)
+			.build());
+
+		leaveMembership.modifyStatus(MembershipStatus.LEAVE);
+		groupMembershipRepository.save(leaveMembership);
+
+		MeetingApplicationReqBody request = new MeetingApplicationReqBody("Test Application");
+
+		// When
+		MeetingApplication savedApplication = meetingApplicationService.create(group.getId(), request, member.getId());
+
+		// Then
+		// 기존 GroupMembership의 상태가 PENDING으로 변경되었는지 확인
+		GroupMembership updatedMembership = groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(group.getId(), member.getId(), false)
+			.orElseThrow();
+		assertThat(updatedMembership.getStatus()).isEqualTo(MembershipStatus.PENDING);
+
+		// MeetingApplication이 저장되었는지 확인
+		List<MeetingApplication> applications = meetingApplicationRepository.findByGroupIdAndDisabled(group.getId(), false);
 		assertThat(applications).isNotNull();
-		assertThat(applications.size()).isEqualTo(0);
+		assertThat(applications.size()).isEqualTo(1);
 
-		// 그룹 승인 멤버는 1명이여야 함
-		int approvedMembershipCount = groupMembershipRepository.countByGroupIdAndStatusAndDisabled(group.getId(), MembershipStatus.APPROVED, false);
-		assertThat(approvedMembershipCount).isEqualTo(1);
+		// 저장된 MeetingApplication이 올바른 값인지 확인
+		MeetingApplication application = applications.get(0);
+		assertThat(application.getMember().getId()).isEqualTo(member.getId());
+		assertThat(application.getGroup().getId()).isEqualTo(group.getId());
+		assertThat(application.getContext()).isEqualTo(request.context());
+	}
+
+
+	@Test
+	@DisplayName("Success : 기존 그룹 멤버십이 REJECTED 상태인 회원이 신청하면 PENDING으로 변경되고 MeetingApplication이 저장")
+	void t4() {
+		GroupMembership rejectedMembership = groupMembershipRepository.save(GroupMembership.builder()
+			.group(group)
+			.member(member)
+			.groupRole(GroupRole.PARTICIPANT)
+			.build());
+
+		rejectedMembership.modifyStatus(MembershipStatus.REJECTED);
+		groupMembershipRepository.save(rejectedMembership);
+
+		MeetingApplicationReqBody request = new MeetingApplicationReqBody("Test Application");
+
+		// When
+		MeetingApplication savedApplication = meetingApplicationService.create(group.getId(), request, member.getId());
+
+		// Then
+		// 기존 GroupMembership의 상태가 PENDING으로 변경되었는지 확인
+		GroupMembership updatedMembership = groupMembershipRepository.findByGroupIdAndMemberIdAndDisabled(group.getId(), member.getId(), false)
+			.orElseThrow();
+		assertThat(updatedMembership.getStatus()).isEqualTo(MembershipStatus.PENDING);
+
+		// MeetingApplication이 저장되었는지 확인
+		List<MeetingApplication> applications = meetingApplicationRepository.findByGroupIdAndDisabled(group.getId(), false);
+		assertThat(applications).isNotNull();
+		assertThat(applications.size()).isEqualTo(1);
+
+		// 저장된 MeetingApplication이 올바른 값인지 확인
+		MeetingApplication application = applications.get(0);
+		assertThat(application.getMember().getId()).isEqualTo(member.getId());
+		assertThat(application.getGroup().getId()).isEqualTo(group.getId());
+		assertThat(application.getContext()).isEqualTo(request.context());
 	}
 
 }


### PR DESCRIPTION
#88 
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- meetingApplicationService에서 한 transaction으로 meetingApplication, groupMembership 엔티티 생성
- 서비스 테스트 작성
- 컨트롤러 테스트 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- meetingApplication 서비스에서 create 실행 시 meetingApplication과 groupMembership 동시에 생성
- REJECTED, LEAVE status를 가진 회원은 추가로 meetingApplication 생성하지 않고 pending으로 status만 변경
- meetingApplication 컨트롤러에서 인원 제한 검증 메서드 통과 후 create 메서드로 넘어감
- 서비스, 컨트롤러 테스트 (통과)

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
