### PR TITLE
[Refactor]: [FE][BE] 채팅방 목록, 채팅방 화면 수정

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/chat/room/dto/response/ChatRoomListResponse.java
+++ b/backend/src/main/java/com/app/backend/domain/chat/room/dto/response/ChatRoomListResponse.java
@@ -5,13 +5,14 @@ import com.app.backend.domain.chat.room.entity.ChatRoom;
 import lombok.Builder;
 
 @Builder
-public record ChatRoomListResponse(Long chatRoomId, Long groupId, String groupName) {
+public record ChatRoomListResponse(Long chatRoomId, Long groupId, String groupName, Long participant) {
 
-	public static ChatRoomListResponse from(ChatRoom chatRoom) {
+	public static ChatRoomListResponse from(ChatRoom chatRoom, Long participant) {
 		return ChatRoomListResponse.builder()
 			.chatRoomId(chatRoom.getId())
 			.groupId(chatRoom.getGroup().getId())
 			.groupName(chatRoom.getGroup().getName())
+			.participant(participant)
 			.build();
 	}
 }

--- a/backend/src/main/java/com/app/backend/domain/chat/room/repository/ChatRoomRepositoryCustom.java
+++ b/backend/src/main/java/com/app/backend/domain/chat/room/repository/ChatRoomRepositoryCustom.java
@@ -4,11 +4,11 @@ import java.util.List;
 import java.util.Optional;
 
 import com.app.backend.domain.chat.room.dto.response.ChatRoomDetailResponse;
-import com.app.backend.domain.chat.room.entity.ChatRoom;
+import com.app.backend.domain.chat.room.dto.response.ChatRoomListResponse;
 
 public interface ChatRoomRepositoryCustom {
 
-	List<ChatRoom> findAllByMemberId(Long memberId);
+	List<ChatRoomListResponse> findAllByMemberId(Long memberId);
 
 	Optional<ChatRoomDetailResponse> findByIdWithApprovedMembers(Long id);
 }

--- a/backend/src/main/java/com/app/backend/domain/chat/room/service/ChatRoomService.java
+++ b/backend/src/main/java/com/app/backend/domain/chat/room/service/ChatRoomService.java
@@ -21,7 +21,7 @@ public class ChatRoomService {
 	private final ChatRoomRepository chatRoomRepository;
 
 	public List<ChatRoomListResponse> getChatRoomsByMemberId(Long memberId) {
-		return chatRoomRepository.findAllByMemberId(memberId).stream().map(ChatRoomListResponse::from).toList();
+		return chatRoomRepository.findAllByMemberId(memberId);
 	}
 
 	public ChatRoomDetailResponse getChatRoomDetailsWithApprovedMembers(Long chatRoomId) {

--- a/backend/src/test/java/com/app/backend/domain/chat/room/service/ChatRoomServiceTest.java
+++ b/backend/src/test/java/com/app/backend/domain/chat/room/service/ChatRoomServiceTest.java
@@ -14,9 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.app.backend.domain.chat.room.dto.response.ChatRoomListResponse;
-import com.app.backend.domain.chat.room.entity.ChatRoom;
 import com.app.backend.domain.chat.room.repository.ChatRoomRepository;
-import com.app.backend.domain.group.entity.Group;
 
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceTest {
@@ -33,17 +31,21 @@ class ChatRoomServiceTest {
 		//given
 		Long MemberId = 1L;
 
-		ChatRoom chatRoom1 = ChatRoom.builder()
-			.id(1L)
-			.group(Group.builder().id(1L).build())
+		ChatRoomListResponse chatRoom1 = ChatRoomListResponse.builder()
+			.chatRoomId(1L)
+			.groupId(1L)
+			.groupName("Group 1")
+			.participant(10L) // 가상의 참여 인원 수 추가
 			.build();
 
-		ChatRoom chatRoom2 = ChatRoom.builder()
-			.id(2L)
-			.group(Group.builder().id(3L).build())
+		ChatRoomListResponse chatRoom2 = ChatRoomListResponse.builder()
+			.chatRoomId(2L)
+			.groupId(3L)
+			.groupName("Group 2")
+			.participant(5L) // 가상의 참여 인원 수 추가
 			.build();
 
-		List<ChatRoom> chatRooms = List.of(chatRoom1, chatRoom2);
+		List<ChatRoomListResponse> chatRooms = List.of(chatRoom1, chatRoom2);
 		when(chatRoomRepository.findAllByMemberId(any(Long.class))).thenReturn(chatRooms);
 
 		//when
@@ -52,11 +54,13 @@ class ChatRoomServiceTest {
 		//then
 		assertThat(result).isNotNull();
 		assertThat(result.size()).isEqualTo(2);
-		assertThat(result.get(0).chatRoomId()).isEqualTo(chatRoom1.getId());
-		assertThat(result.get(0).groupId()).isEqualTo(chatRoom1.getGroup().getId());
-		assertThat(result.get(1).chatRoomId()).isEqualTo(chatRoom2.getId());
-		assertThat(result.get(1).groupId()).isEqualTo(chatRoom2.getGroup().getId());
-
-
+		assertThat(result.get(0).chatRoomId()).isEqualTo(chatRoom1.chatRoomId());
+		assertThat(result.get(0).groupId()).isEqualTo(chatRoom1.groupId());
+		assertThat(result.get(0).groupName()).isEqualTo(chatRoom1.groupName());
+		assertThat(result.get(0).participant()).isEqualTo(chatRoom1.participant());
+		assertThat(result.get(1).chatRoomId()).isEqualTo(chatRoom2.chatRoomId());
+		assertThat(result.get(1).groupId()).isEqualTo(chatRoom2.groupId());
+		assertThat(result.get(1).groupName()).isEqualTo(chatRoom2.groupName());
+		assertThat(result.get(1).participant()).isEqualTo(chatRoom2.participant());
 	}
 }

--- a/frontend/src/app/chat/ClientPage.tsx
+++ b/frontend/src/app/chat/ClientPage.tsx
@@ -1,10 +1,13 @@
 "use client";
+
 import { useEffect, useState } from "react";
+import { Users } from 'lucide-react';
 
 interface ChatRoom {
   chatRoomId: number;
   groupId: number;
   groupName: string;
+  participant: number;
 }
 
 interface ApiResponse {
@@ -73,8 +76,9 @@ export default function ChatPage() {
               onClick={() => window.location.href = `/chat/${room.chatRoomId}`}
             >
               <h2 className="font-semibold">{room.groupName}</h2>
-              <p className="text-sm text-gray-500">
-                모임 ID: {room.groupId}
+              <p className="text-sm text-gray-500 flex items-center gap-1">
+                <Users className="w-4 h-4" />
+                {room.participant}
               </p>
             </div>
           ))

--- a/frontend/src/app/chat/[id]/ClientPage.tsx
+++ b/frontend/src/app/chat/[id]/ClientPage.tsx
@@ -198,19 +198,26 @@ export default function ChatRoom() {
                         </div>
                         
                         {/* 해당 날짜의 메시지들 */}
-                        {dateMessages.map((message: Message) => (
-                            <div key={message.id} className="flex flex-col mb-2">
-                                <div className="flex items-center gap-2">
-                                    <span className="font-bold dark:text-white">{message.senderNickname}</span>
-                                    <span className="text-xs text-gray-500 dark:text-gray-400">
-                                        {formatTime(new Date(message.createdAt))}
-                                    </span>
+                        {dateMessages.map((message: Message) => {
+                            const isMyMessage = message.senderId === loginMember.id;
+                            return (
+                                <div key={message.id} 
+                                    className={`flex flex-col mb-2 ${isMyMessage ? 'items-end' : 'items-start'}`}>
+                                    <span className="font-bold dark:text-white mb-1">{!isMyMessage && message.senderNickname}</span>
+                                    <div className={`flex items-end gap-2 ${isMyMessage ? 'flex-row-reverse' : ''}`}>
+                                        <p className={`rounded-lg p-2 max-w-[70%] whitespace-pre-wrap break-words
+                                            ${isMyMessage 
+                                                ? 'bg-blue-100 text-blue-900 dark:bg-blue-900 dark:text-blue-100' 
+                                                : 'bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'}`}>
+                                            {message.content}
+                                        </p>
+                                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                                            {formatTime(new Date(message.createdAt))}
+                                        </span>
+                                    </div>
                                 </div>
-                                <p className="mt-1 bg-gray-100 dark:bg-gray-700 rounded-lg p-2 max-w-[70%] dark:text-white">
-                                    {message.content}
-                                </p>
-                            </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 ))}
                 <div ref={messagesEndRef} />


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- #124 

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 채팅방 목록에서 채팅방 별로 참여자 수도 같이 가져오도록 수정
- 화면에서 그룹 아이디 대신 참여자 수 랜더링
- 채팅방에서 내 메세지와 상대방 메세지 왼쪽 오른쪽으로 구분
