### PR TITLE
[FIX]: [BE] 모임 페이징 목록 조회 시 DTO -> 쿼리스트링 사용으로 수정

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/group/repository/GroupRepositoryImpl.java
+++ b/backend/src/main/java/com/app/backend/domain/group/repository/GroupRepositoryImpl.java
@@ -143,7 +143,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
      * @return 모임 목록
      */
     @Override
-    public List<Group> findAllByCategoryAndNameContainingAndRegion(@NotNull final String categoryName,
+    public List<Group> findAllByCategoryAndNameContainingAndRegion(final String categoryName,
                                                                    final String name,
                                                                    final String province,
                                                                    final String city,
@@ -151,8 +151,12 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                                                    @NotNull final Boolean disabled) {
         QGroup group = QGroup.group;
         return jpaQueryFactory.selectFrom(group)
-                              .where(group.category.name.eq(categoryName),
-                                     group.name.contains(name),
+                              .where(categoryName != null && !categoryName.isBlank()
+                                     ? group.category.name.eq(categoryName)
+                                     : null,
+                                     name != null && !name.isBlank()
+                                     ? group.name.contains(name)
+                                     : null,
                                      getRegionCondition(province, city, town, group),
                                      group.disabled.eq(disabled))
                               .fetch();
@@ -170,7 +174,7 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
      * @return 모임 페이징 목록
      */
     @Override
-    public Page<Group> findAllByCategoryAndNameContainingAndRegion(@NotNull final String categoryName,
+    public Page<Group> findAllByCategoryAndNameContainingAndRegion(final String categoryName,
                                                                    final String name,
                                                                    final String province,
                                                                    final String city,
@@ -179,8 +183,12 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                                                    @NotNull final Pageable pageable) {
         QGroup group = QGroup.group;
         List<Group> content = jpaQueryFactory.selectFrom(group)
-                                             .where(group.category.name.eq(categoryName),
-                                                    group.name.contains(name),
+                                             .where(categoryName != null && !categoryName.isBlank()
+                                                    ? group.category.name.eq(categoryName)
+                                                    : null,
+                                                    name != null && !name.isBlank()
+                                                    ? group.name.contains(name)
+                                                    : null,
                                                     getRegionCondition(province, city, town, group),
                                                     group.disabled.eq(disabled))
                                              .orderBy(getSortCondition(pageable, group))
@@ -189,8 +197,12 @@ public class GroupRepositoryImpl implements GroupRepositoryCustom {
                                              .fetch();
         JPAQuery<Long> count = jpaQueryFactory.select(group.count())
                                               .from(group)
-                                              .where(group.category.name.eq(categoryName),
-                                                     group.name.contains(name),
+                                              .where(categoryName != null && !categoryName.isBlank()
+                                                     ? group.category.name.eq(categoryName)
+                                                     : null,
+                                                     name != null && !name.isBlank()
+                                                     ? group.name.contains(name)
+                                                     : null,
                                                      getRegionCondition(province, city, town, group),
                                                      group.disabled.eq(disabled));
         return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);

--- a/backend/src/test/java/com/app/backend/domain/group/controller/GroupControllerTest.java
+++ b/backend/src/test/java/com/app/backend/domain/group/controller/GroupControllerTest.java
@@ -217,13 +217,16 @@ class GroupControllerTest extends WebMvcTestSupporter {
                                                             .city("test city10")
                                                             .town("test town10")
                                                             .build();
-        String requestBody = objectMapper.writeValueAsString(requestDto);
 
         //When
         ResultActions resultActions = mockMvc.perform(get("/api/v1/groups")
                                                               .accept(MediaType.APPLICATION_JSON_VALUE)
                                                               .contentType(MediaType.APPLICATION_JSON_VALUE)
-                                                              .content(requestBody)
+                                                              .param("categoryName", "category")
+                                                              .param("keyword", "1")
+                                                              .param("province", "test province10")
+                                                              .param("city", "test city10")
+                                                              .param("town", "test town10")
                                                               .param("page", "0")
                                                               .param("size", "10")
                                                               .param("sort", "createdAt,DESC"));


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 기존: 모임 페이징 조회 시 DTO 사용
- 수정: DTO 대신 쿼리스트링 사용
- GroupRepositoryImpl 메서드 수정
  - 카테고리명, 모임 이름, 상세 주소로 모임 목록/페이징 목록 조회 시 파라미터 null 허용으로 수정
- 테스트 코드 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->