### PR TITLE
[Bug] 댓글 조회에는 부모 댓글만 보이도록 수정

### DIFF
--- a/backend/src/main/java/com/app/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/app/backend/domain/comment/repository/CommentRepository.java
@@ -12,7 +12,7 @@ import com.app.backend.domain.post.entity.Post;
 public interface CommentRepository  extends JpaRepository<Comment, Long> {
 	Optional<Comment> findByIdAndDisabled(Long id, Boolean disabled);
 
-	Page<Comment> findByPostAndDisabled(Post post, boolean b, Pageable pageable);
+	Page<Comment> findByPostAndDisabledAndParentIsNull(Post post, boolean disabled, Pageable pageable);
 
 	Page<Comment> findByParentAndDisabled(Comment comment, boolean b, Pageable pageable);
 }

--- a/backend/src/main/java/com/app/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/app/backend/domain/comment/service/CommentService.java
@@ -120,7 +120,7 @@ public class CommentService {
 
 		Post post = getPostValidate(postId);
 
-		Page<Comment> comments = commentRepository.findByPostAndDisabled(post, false, pageable);
+		Page<Comment> comments = commentRepository.findByPostAndDisabledAndParentIsNull(post, false, pageable);
 
 		return comments.map(CommentResponse.CommentList::from);
 	}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 댓글 조회할 때 대댓글도 같이 보이는 현상을 부모 댓글만 보이도록 수정

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 리포지터리에 부모가 없는 댓글(자신이 부모이기 때문에)을 찾아서 조회한다.

